### PR TITLE
👷 ci: pins the uv version to v0.4.22

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,8 +14,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      # We are pinning uv to lower version to workaround the existing
+      # bugs in setuptools build system. We can unpin onces the issue
+      # is resolved in upstream repos.
+      # Bug: https://github.com/pypa/setuptools/issues/4759
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: '0.4.22'
 
       - name: Publish to pypi
         run: |


### PR DESCRIPTION
### Description

Due to a bug in upstream packages, we have to ping `uv` to version `v0.4.22`.