### PR TITLE
fix: allow user change for v2-apiserver hostname.

### DIFF
--- a/rapyuta_io_sdk_v2/config.py
+++ b/rapyuta_io_sdk_v2/config.py
@@ -34,8 +34,17 @@ class Configuration:
     project_guid: str = None
     organization_guid: str = None
     environment: str = "ga"  # Default environment is prod
+    v2_api_host: str = None
+    rip_host: str = None
 
     def __post_init__(self):
+        # Normalize empty or whitespace-only host strings to None so that they
+        # are treated the same as "not provided".
+        if isinstance(self.v2_api_host, str):
+            self.v2_api_host = self.v2_api_host.strip() or None
+        if isinstance(self.rip_host, str):
+            self.rip_host = self.rip_host.strip() or None
+
         self.hosts = {}
         self.set_environment(self.environment)
 
@@ -109,7 +118,6 @@ class Configuration:
         if with_group and group_guid:
             headers["groupguid"] = group_guid
 
-
         custom_client_request_id = os.getenv("REQUEST_ID")
         if custom_client_request_id:
             headers["X-Request-ID"] = custom_client_request_id
@@ -143,31 +151,47 @@ class Configuration:
     def set_environment(self, name: str = None) -> None:
         """Set the environment for the configuration.
 
+        Populates ``hosts`` with the correct URLs for *name*.  If the caller
+        provided ``v2_api_host`` or ``rip_host`` at construction time those
+        values are used as-is; otherwise the canonical defaults for the
+        environment are applied.  Calling this method again with a different
+        environment name always recomputes the default slots so that switching
+        environments produces correct URLs.
+
         Args:
-            name (str): Name of the environment, default is ga.
+            name (str): Name of the environment. Defaults to ``"ga"`` (production).
 
         Raises:
-            ValidationError: If the environment is invalid.
+            ValidationError: If *name* is not a recognised environment.
         """
-        name = name or "ga"  # Default to prod.
+        name = name or "ga"
 
-        if name == "local":
-            # Allow overriding the local API host via environment variables.
-            # Priority: LOCAL_V2API_HOST > default fallback.
-            override_host = os.getenv("LOCAL_V2API_HOST") or "http://gateway/io"
-            self.hosts["environment"] = name
-            self.hosts["v2api_host"] = override_host
-            return
-
-        if name == "ga":
-            self.hosts["environment"] = "ga"
-            self.hosts["rip_host"] = "https://garip.apps.okd4v2.prod.rapyuta.io"
-            self.hosts["v2api_host"] = "https://api.rapyuta.io"
-            return
-
-        if not (name in NAMED_ENVIRONMENTS or name.startswith("pr")):
+        if (
+            name not in ("local", "ga")
+            and name not in NAMED_ENVIRONMENTS
+            and not name.startswith("pr")
+        ):
             raise ValidationError("invalid environment")
 
         self.hosts["environment"] = name
-        self.hosts["rip_host"] = f"https://{name}rip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
-        self.hosts["v2api_host"] = f"https://{name}api.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+        if name == "local":
+            self.hosts["v2api_host"] = self.v2_api_host or (
+                os.getenv("LOCAL_V2API_HOST") or "http://gateway/io"
+            )
+            self.hosts["rip_host"] = self.rip_host or (
+                os.getenv("LOCAL_RIP_HOST") or "http://rip"
+            )
+        elif name == "ga":
+            self.hosts["rip_host"] = (
+                self.rip_host or "https://garip.apps.okd4v2.prod.rapyuta.io"
+            )
+            self.hosts["v2api_host"] = self.v2_api_host or "https://api.rapyuta.io"
+        else:
+            # Staging environments: qa, dev, pr*
+            self.hosts["rip_host"] = (
+                self.rip_host or f"https://{name}rip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+            )
+            self.hosts["v2api_host"] = (
+                self.v2_api_host or f"https://{name}api.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+            )

--- a/tests/async_tests/test_user_async.py
+++ b/tests/async_tests/test_user_async.py
@@ -3,7 +3,11 @@ import pytest
 
 # ruff: noqa: F811, F401
 from rapyuta_io_sdk_v2.exceptions import UnauthorizedAccessError
-from tests.data.mock_data import mock_response_user as mock_response_user, user_body, user_permissions_mock
+from tests.data.mock_data import (
+    mock_response_user as mock_response_user,
+    user_body,
+    user_permissions_mock,
+)
 from tests.utils.fixtures import async_client
 
 
@@ -121,7 +125,9 @@ async def test_get_user_permissions_success(async_client, user_permissions_mock,
 
 
 @pytest.mark.asyncio
-async def test_get_user_permissions_with_config_org(async_client, user_permissions_mock, mocker):
+async def test_get_user_permissions_with_config_org(
+    async_client, user_permissions_mock, mocker
+):
     """Test async get_user_permissions using organization_guid from config."""
     mock_get = mocker.patch("httpx.AsyncClient.get")
 
@@ -158,4 +164,3 @@ async def test_get_user_permissions_unauthorized(async_client, mocker):
             organization_guid="org-testorg123456789abcdef",
         )
     assert "user cannot be authenticated" in str(exc.value)
-

--- a/tests/data/mock_data.py
+++ b/tests/data/mock_data.py
@@ -1032,4 +1032,3 @@ def user_permissions_mock() -> dict[str, Any]:
             },
         },
     }
-

--- a/tests/sync_tests/test_config.py
+++ b/tests/sync_tests/test_config.py
@@ -123,9 +123,11 @@ def test_set_environment_pr_hosts():
     assert config.hosts["rip_host"] == f"https://pr123rip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
 
 
-def test_set_environment_local_default_host():
+def test_set_environment_local_default_host(monkeypatch):
     # "local" environment falls back to hardcoded defaults for both hosts
     # when neither instance fields nor env vars are set.
+    monkeypatch.delenv("LOCAL_V2API_HOST", raising=False)
+    monkeypatch.delenv("LOCAL_RIP_HOST", raising=False)
     config = Configuration(environment="local")
     assert config.hosts["environment"] == "local"
     assert config.hosts["v2api_host"] == "http://gateway/io"

--- a/tests/sync_tests/test_config.py
+++ b/tests/sync_tests/test_config.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 from rapyuta_io_sdk_v2.config import Configuration
+from rapyuta_io_sdk_v2.constants import STAGING_ENVIRONMENT_SUBDOMAIN
+from rapyuta_io_sdk_v2.exceptions import ValidationError
 from tests.data.mock_data import mock_config, config_obj
 
 
@@ -72,3 +74,256 @@ def test_get_headers_with_request_id(mocker, config_obj):
     assert headers["organizationguid"] == "mock_org_guid"
     assert headers["project"] == "mock_project_guid"
     assert headers["X-Request-ID"] == "mock_request_id"
+
+
+# ---------------------------------------------------------------------------
+# set_environment() — default hosts per environment
+# ---------------------------------------------------------------------------
+
+
+def test_set_environment_default_ga_hosts():
+    # The default environment is "ga"; verify production hosts are applied.
+    config = Configuration()
+    assert config.hosts["environment"] == "ga"
+    assert config.hosts["v2api_host"] == "https://api.rapyuta.io"
+    assert config.hosts["rip_host"] == "https://garip.apps.okd4v2.prod.rapyuta.io"
+
+
+def test_set_environment_explicit_ga_hosts():
+    # Explicitly passing environment="ga" must produce the same production hosts.
+    config = Configuration(environment="ga")
+    assert config.hosts["environment"] == "ga"
+    assert config.hosts["v2api_host"] == "https://api.rapyuta.io"
+    assert config.hosts["rip_host"] == "https://garip.apps.okd4v2.prod.rapyuta.io"
+
+
+def test_set_environment_qa_hosts():
+    # "qa" is a named staging environment; hosts must use the staging subdomain.
+    config = Configuration(environment="qa")
+    assert config.hosts["environment"] == "qa"
+    assert config.hosts["v2api_host"] == f"https://qaapi.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+    assert config.hosts["rip_host"] == f"https://qarip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+def test_set_environment_dev_hosts():
+    # "dev" is a named staging environment; hosts must use the staging subdomain.
+    config = Configuration(environment="dev")
+    assert config.hosts["environment"] == "dev"
+    assert config.hosts["v2api_host"] == f"https://devapi.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+    assert config.hosts["rip_host"] == f"https://devrip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+def test_set_environment_pr_hosts():
+    # PR environments are identified by the "pr" prefix.
+    config = Configuration(environment="pr123")
+    assert config.hosts["environment"] == "pr123"
+    assert (
+        config.hosts["v2api_host"] == f"https://pr123api.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+    )
+    assert config.hosts["rip_host"] == f"https://pr123rip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+def test_set_environment_local_default_host():
+    # "local" environment falls back to hardcoded defaults for both hosts
+    # when neither instance fields nor env vars are set.
+    config = Configuration(environment="local")
+    assert config.hosts["environment"] == "local"
+    assert config.hosts["v2api_host"] == "http://gateway/io"
+    assert config.hosts["rip_host"] == "http://rip"
+
+
+def test_set_environment_local_env_var_override(monkeypatch):
+    # LOCAL_V2API_HOST overrides the v2api default; rip falls back to "http://rip".
+    monkeypatch.setenv("LOCAL_V2API_HOST", "http://localhost:8080")
+    config = Configuration(environment="local")
+    assert config.hosts["environment"] == "local"
+    assert config.hosts["v2api_host"] == "http://localhost:8080"
+    assert config.hosts["rip_host"] == "http://rip"
+
+
+def test_set_environment_local_rip_env_var_override(monkeypatch):
+    # LOCAL_RIP_HOST overrides the rip default; v2api falls back to "http://gateway/io".
+    monkeypatch.setenv("LOCAL_RIP_HOST", "http://localhost:9090")
+    config = Configuration(environment="local")
+    assert config.hosts["environment"] == "local"
+    assert config.hosts["v2api_host"] == "http://gateway/io"
+    assert config.hosts["rip_host"] == "http://localhost:9090"
+
+
+def test_set_environment_local_both_env_vars_override(monkeypatch):
+    # Both LOCAL_V2API_HOST and LOCAL_RIP_HOST override the hardcoded defaults.
+    monkeypatch.setenv("LOCAL_V2API_HOST", "http://localhost:8080")
+    monkeypatch.setenv("LOCAL_RIP_HOST", "http://localhost:9090")
+    config = Configuration(environment="local")
+    assert config.hosts["environment"] == "local"
+    assert config.hosts["v2api_host"] == "http://localhost:8080"
+    assert config.hosts["rip_host"] == "http://localhost:9090"
+
+
+def test_set_environment_none_defaults_to_ga():
+    # Passing None to set_environment() must be treated identically to "ga".
+    config = Configuration(environment="ga")
+    config.set_environment(None)
+    assert config.hosts["environment"] == "ga"
+    assert config.hosts["v2api_host"] == "https://api.rapyuta.io"
+    assert config.hosts["rip_host"] == "https://garip.apps.okd4v2.prod.rapyuta.io"
+
+
+# ---------------------------------------------------------------------------
+# set_environment() — user-supplied hosts take priority over env defaults
+# ---------------------------------------------------------------------------
+
+
+def test_custom_v2api_host_used_over_ga_default():
+    # v2_api_host on the instance is used instead of the "ga" default.
+    config = Configuration(environment="ga", v2_api_host="https://custom.api.example.com")
+    assert config.hosts["v2api_host"] == "https://custom.api.example.com"
+    # rip_host was not supplied so the environment default applies.
+    assert config.hosts["rip_host"] == "https://garip.apps.okd4v2.prod.rapyuta.io"
+
+
+def test_custom_rip_host_used_over_ga_default():
+    # rip_host on the instance is used instead of the "ga" default.
+    config = Configuration(environment="ga", rip_host="https://custom.rip.example.com")
+    assert config.hosts["rip_host"] == "https://custom.rip.example.com"
+    # v2api_host was not supplied so the environment default applies.
+    assert config.hosts["v2api_host"] == "https://api.rapyuta.io"
+
+
+def test_both_custom_hosts_used_over_ga_defaults():
+    # Both hosts supplied — neither is overwritten by the environment logic.
+    config = Configuration(
+        environment="ga",
+        v2_api_host="https://custom.api.example.com",
+        rip_host="https://custom.rip.example.com",
+    )
+    assert config.hosts["v2api_host"] == "https://custom.api.example.com"
+    assert config.hosts["rip_host"] == "https://custom.rip.example.com"
+
+
+def test_custom_v2api_host_used_over_staging_default():
+    # Custom v2_api_host is also honoured for staging environments.
+    config = Configuration(environment="qa", v2_api_host="https://custom.api.example.com")
+    assert config.hosts["v2api_host"] == "https://custom.api.example.com"
+    # rip_host was not supplied; staging default applies.
+    assert config.hosts["rip_host"] == f"https://qarip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+def test_custom_rip_host_used_over_staging_default():
+    # rip_host supplied at construction is used instead of the staging computed default.
+    config = Configuration(environment="qa", rip_host="https://custom.rip.example.com")
+    assert config.hosts["rip_host"] == "https://custom.rip.example.com"
+    # v2api_host was not supplied; staging default applies.
+    assert config.hosts["v2api_host"] == f"https://qaapi.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+def test_custom_rip_host_preserved_across_staging_environment_switch():
+    # rip_host set on the instance must survive a call to set_environment() that
+    # targets a different staging environment; only the default slot for the new
+    # environment name should change, not the user-supplied value.
+    config = Configuration(environment="qa", rip_host="https://custom.rip.example.com")
+    assert config.hosts["rip_host"] == "https://custom.rip.example.com"
+
+    config.set_environment("pr99")
+
+    assert config.hosts["environment"] == "pr99"
+    assert config.hosts["rip_host"] == "https://custom.rip.example.com"
+    # v2api_host was not supplied; it must be recomputed for the new environment.
+    assert (
+        config.hosts["v2api_host"] == f"https://pr99api.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+    )
+
+
+def test_custom_v2api_host_used_over_local_default():
+    # Custom v2_api_host is honoured for the "local" environment; rip falls back to "http://rip".
+    config = Configuration(environment="local", v2_api_host="http://localhost:9000")
+    assert config.hosts["v2api_host"] == "http://localhost:9000"
+    assert config.hosts["rip_host"] == "http://rip"
+
+
+def test_custom_rip_host_used_over_local_default():
+    # Custom rip_host is honoured for the "local" environment; v2api falls back to "http://gateway/io".
+    config = Configuration(environment="local", rip_host="http://localhost:9091")
+    assert config.hosts["rip_host"] == "http://localhost:9091"
+    assert config.hosts["v2api_host"] == "http://gateway/io"
+
+
+def test_whitespace_only_host_treated_as_not_provided():
+    # A whitespace-only string is normalised to None in __post_init__,
+    # so the environment default is applied as if no host were given.
+    config = Configuration(environment="ga", v2_api_host="   ")
+    assert config.hosts["v2api_host"] == "https://api.rapyuta.io"
+
+
+# ---------------------------------------------------------------------------
+# set_environment() — switching environments after construction
+# ---------------------------------------------------------------------------
+
+
+def test_switch_environment_updates_environment_key():
+    # The "environment" key in hosts is always updated on each call.
+    config = Configuration(environment="ga")
+    assert config.hosts["environment"] == "ga"
+
+    config.set_environment("dev")
+    assert config.hosts["environment"] == "dev"
+
+    config.set_environment("pr42")
+    assert config.hosts["environment"] == "pr42"
+
+
+def test_switch_environment_recomputes_default_hosts():
+    # Switching environment recomputes host URLs to the new environment's
+    # defaults when no user-supplied hosts are set on the instance.
+    config = Configuration(environment="ga")
+    assert config.hosts["v2api_host"] == "https://api.rapyuta.io"
+    assert config.hosts["rip_host"] == "https://garip.apps.okd4v2.prod.rapyuta.io"
+
+    config.set_environment("dev")
+
+    assert config.hosts["environment"] == "dev"
+    assert config.hosts["v2api_host"] == f"https://devapi.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+    assert config.hosts["rip_host"] == f"https://devrip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+def test_switch_environment_from_ga_to_staging():
+    # Switching from "ga" to "qa" updates both host URLs.
+    config = Configuration(environment="ga")
+    assert config.hosts["v2api_host"] == "https://api.rapyuta.io"
+
+    config.set_environment("qa")
+
+    assert config.hosts["environment"] == "qa"
+    assert config.hosts["v2api_host"] == f"https://qaapi.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+    assert config.hosts["rip_host"] == f"https://qarip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+def test_switch_environment_preserves_user_host():
+    # When v2_api_host is set on the instance it is preserved across environment
+    # switches; the unpinned rip_host is recomputed for the new environment.
+    config = Configuration(environment="ga", v2_api_host="https://custom.api.example.com")
+    assert config.hosts["v2api_host"] == "https://custom.api.example.com"
+
+    config.set_environment("qa")
+
+    assert config.hosts["environment"] == "qa"
+    assert config.hosts["v2api_host"] == "https://custom.api.example.com"
+    assert config.hosts["rip_host"] == f"https://qarip.{STAGING_ENVIRONMENT_SUBDOMAIN}"
+
+
+# ---------------------------------------------------------------------------
+# set_environment() — validation
+# ---------------------------------------------------------------------------
+
+
+def test_set_environment_invalid_raises_validation_error():
+    # An entirely unknown environment name must raise ValidationError.
+    with pytest.raises(ValidationError):
+        Configuration(environment="invalid_env")
+
+
+def test_set_environment_invalid_direct_call_raises_validation_error():
+    # Calling set_environment() directly with a bad name must also raise.
+    config = Configuration(environment="ga")
+    with pytest.raises(ValidationError):
+        config.set_environment("not_a_valid_env")

--- a/tests/sync_tests/test_user.py
+++ b/tests/sync_tests/test_user.py
@@ -112,7 +112,9 @@ def test_get_user_permissions_success(client, user_permissions_mock, mocker: Moc
     assert call_kwargs["headers"]["userguid"] == user_guid
 
 
-def test_get_user_permissions_with_config_org(client, user_permissions_mock, mocker: MockFixture):
+def test_get_user_permissions_with_config_org(
+    client, user_permissions_mock, mocker: MockFixture
+):
     """Test get_user_permissions using organization_guid from config."""
     mock_get = mocker.patch("httpx.Client.get")
 
@@ -148,4 +150,3 @@ def test_get_user_permissions_unauthorized(client, mocker: MockFixture):
             organization_guid="org-testorg123456789abcdef",
         )
     assert "user cannot be authenticated" in str(exc.value)
-


### PR DESCRIPTION
This PR includes changes to allow user to specify v2-api host and rip host, instead of populated by `set_environment` method.