### PR TITLE
feat(models): add networkInterface field to DeploymentSpec

### DIFF
--- a/rapyuta_io_sdk_v2/models/deployment.py
+++ b/rapyuta_io_sdk_v2/models/deployment.py
@@ -161,6 +161,13 @@ class DeploymentSpec(BaseModel):
     features: DeploymentFeatures | None = None
     staticRoutes: list[DeploymentStaticRoute] | None = None
     serviceAccount: str | None = None
+    networkInterface: str | None = Field(
+        default=None,
+        description=(
+            "Network interface to use for ROS networks. "
+            "Takes precedence over any interface specified in rosNetworks entries."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_runtime_and_volumes(self):


### PR DESCRIPTION
## Summary

Add `networkInterface` as a top-level field in the Pydantic `DeploymentSpec` model, matching the new Go struct field.

### Changes
- Add `networkInterface: str | None` to `DeploymentSpec` in `rapyuta_io_sdk_v2/models/deployment.py`