### PR TITLE
fix: support dict responses in walk_pages and walk_pages_async

### DIFF
--- a/rapyuta_io_sdk_v2/async_client.py
+++ b/rapyuta_io_sdk_v2/async_client.py
@@ -1705,6 +1705,7 @@ class AsyncClient:
         author: str | None = None,
         message: str | None = None,
         project_guid: str | None = None,
+        labels: dict[str, str] | None = None,
         **kwargs,
     ) -> dict[str, Any]:
         """Commit a revision.
@@ -1715,6 +1716,7 @@ class AsyncClient:
             author (str, optional): Revision Author. Defaults to None.
             message (str, optional): Revision Message. Defaults to None.
             project_guid (str, optional): Project GUID. Defaults to None.
+            labels (dict, optional): Labels to set on the revision. Defaults to None.
 
         Returns:
             Revision details as a dictionary.
@@ -1723,6 +1725,9 @@ class AsyncClient:
             "author": author,
             "message": message,
         }
+
+        if labels:
+            config_tree_revision["metadata"] = {"labels": labels}
 
         result = await self.c.patch(
             url=f"{self.v2api_host}/v2/configtrees/{tree_name}/revisions/{revision_id}/",

--- a/rapyuta_io_sdk_v2/client.py
+++ b/rapyuta_io_sdk_v2/client.py
@@ -1657,6 +1657,7 @@ class Client:
         author: str | None = None,
         message: str | None = None,
         project_guid: str | None = None,
+        labels: dict[str, str] | None = None,
         **kwargs,
     ) -> dict[str, Any]:
         """Commit a revision.
@@ -1667,6 +1668,7 @@ class Client:
             author (str, optional): Revision Author. Defaults to None.
             message (str, optional): Revision Message. Defaults to None.
             project_guid (str, optional): Project GUID. Defaults to None.
+            labels (dict, optional): Labels to set on the revision. Defaults to None.
 
         Returns:
             Revision details as a dictionary.
@@ -1675,6 +1677,10 @@ class Client:
             "author": author,
             "message": message,
         }
+
+        if labels:
+            config_tree_revision["metadata"] = {"labels": labels}
+
         result = self.c.patch(
             url=f"{self.v2api_host}/v2/configtrees/{tree_name}/revisions/{revision_id}/",
             headers=self.config.get_headers(project_guid=project_guid, **kwargs),

--- a/rapyuta_io_sdk_v2/utils.py
+++ b/rapyuta_io_sdk_v2/utils.py
@@ -112,15 +112,22 @@ def walk_pages(
 
         data = func(*args, **call_kwargs)
 
-        items = getattr(data, "items", None) or []
+        if isinstance(data, dict):
+            items = data.get("items", [])
+            cont_next = data.get("metadata", {}).get("continue")
+        else:
+            items = getattr(data, "items", [])
+            cont_next = getattr(getattr(data, "metadata", {}), "continue_", None)
+
         if not items:
             break
 
         yield items
 
-        cont: int | None = getattr(getattr(data, "metadata", {}), "continue_", None)
-        if cont is None:
+        if cont_next is None or len(items) < limit:
             break
+
+        cont = cont_next
 
 
 async def walk_pages_async(
@@ -151,12 +158,20 @@ async def walk_pages_async(
 
         data = await func(*args, **call_kwargs)
 
-        items = getattr(data, "items", None) or []
+        if isinstance(data, dict):
+            items = data.get("items", [])
+            cont_next = data.get("metadata", {}).get("continue")
+        else:
+            items = getattr(data, "items", [])
+            cont_next = getattr(getattr(data, "metadata", {}), "continue_", None)
+
         if not items:
             break
 
         yield items
 
-        cont: int | None = getattr(getattr(data, "metadata", {}), "continue_", None)
-        if cont is None:
+        if cont_next is None or len(items) < limit:
             break
+
+        cont = cont_next
+

--- a/tests/async_tests/test_configtree_async.py
+++ b/tests/async_tests/test_configtree_async.py
@@ -261,6 +261,33 @@ async def test_commit_revision_success(async_client, mocker: AsyncMock):
 
 
 @pytest.mark.asyncio
+async def test_commit_revision_with_labels(async_client, mocker: AsyncMock):
+    mock_patch = mocker.patch("httpx.AsyncClient.patch")
+    mock_patch.return_value = httpx.Response(
+        status_code=200,
+        json={
+            "metadata": {
+                "guid": "test_revision_guid",
+                "name": "test_revision",
+                "labels": {"rapyuta.io/milestone": "v1.0"},
+            },
+        },
+    )
+    response = await async_client.commit_revision(
+        tree_name="mock_configtree_name",
+        revision_id="mock_revision_id",
+        labels={"rapyuta.io/milestone": "v1.0"},
+    )
+    assert response["metadata"]["guid"] == "test_revision_guid"
+    assert response["metadata"]["labels"]["rapyuta.io/milestone"] == "v1.0"
+
+    # Verify the request body included metadata.labels
+    call_kwargs = mock_patch.call_args
+    body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+    assert body["metadata"]["labels"] == {"rapyuta.io/milestone": "v1.0"}
+
+
+@pytest.mark.asyncio
 async def test_get_key_in_revision_str(async_client, mocker: AsyncMock):  # noqa: F811
     # Mock the httpx.AsyncClient.get method
     mock_get = mocker.patch("httpx.AsyncClient.get")

--- a/tests/async_tests/test_utils_async.py
+++ b/tests/async_tests/test_utils_async.py
@@ -1,0 +1,170 @@
+import pytest
+from rapyuta_io_sdk_v2.utils import walk_pages_async
+
+
+def _make_sdk_model(items, continue_=None):
+    """Simulate an SDK model response (object with attributes)."""
+
+    class Metadata:
+        pass
+
+    class Response:
+        pass
+
+    meta = Metadata()
+    meta.continue_ = continue_
+
+    resp = Response()
+    resp.items = items
+    resp.metadata = meta
+    return resp
+
+
+async def _collect(gen):
+    pages = []
+    async for page in gen:
+        pages.append(page)
+    return pages
+
+
+class TestWalkPagesAsyncWithDictResponse:
+    """Tests for walk_pages_async when the list function returns a plain dict
+    (e.g. list_configtrees, list_revisions in the configtree SDK client).
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_page(self):
+        async def list_func(cont, limit):
+            return {"items": ["a", "b"], "metadata": {"continue": None}}
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert pages == [["a", "b"]]
+
+    @pytest.mark.asyncio
+    async def test_multiple_pages(self):
+        responses = [
+            {"items": ["a", "b"], "metadata": {"continue": 2}},
+            {"items": ["c", "d"], "metadata": {"continue": 4}},
+            {"items": ["e"], "metadata": {"continue": None}},
+        ]
+        calls = []
+
+        async def list_func(cont, limit):
+            calls.append(cont)
+            return responses.pop(0)
+
+        pages = await _collect(walk_pages_async(list_func, limit=2))
+        assert pages == [["a", "b"], ["c", "d"], ["e"]]
+        assert calls == [0, 2, 4]
+
+    @pytest.mark.asyncio
+    async def test_last_page_with_non_null_continue(self):
+        """API may return a non-null continue value on the last page.
+
+        walk_pages_async must stop when items count < limit to avoid infinite loops.
+        """
+        responses = [
+            {"items": list(range(50)), "metadata": {"continue": 50}},
+            {"items": list(range(5)), "metadata": {"continue": 5}},
+        ]
+        calls = []
+
+        async def list_func(cont, limit):
+            calls.append(cont)
+            return responses.pop(0)
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert len(pages) == 2
+        assert len(pages[0]) == 50
+        assert len(pages[1]) == 5
+        assert calls == [0, 50]
+
+    @pytest.mark.asyncio
+    async def test_empty_items_stops_iteration(self):
+        async def list_func(cont, limit):
+            return {"items": [], "metadata": {"continue": 5}}
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert pages == []
+
+    @pytest.mark.asyncio
+    async def test_missing_items_key_stops_iteration(self):
+        async def list_func(cont, limit):
+            return {"metadata": {"continue": 5}}
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert pages == []
+
+    @pytest.mark.asyncio
+    async def test_missing_metadata_stops_after_first_page(self):
+        async def list_func(cont, limit):
+            return {"items": ["x"]}
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert pages == [["x"]]
+
+    @pytest.mark.asyncio
+    async def test_kwargs_forwarded(self):
+        received = {}
+
+        async def list_func(cont, limit, tree_name=None, label_selector=None):
+            received["tree_name"] = tree_name
+            received["label_selector"] = label_selector
+            return {"items": ["r1"], "metadata": {}}
+
+        await _collect(
+            walk_pages_async(list_func, tree_name="my-tree", label_selector=["env=prod"])
+        )
+        assert received["tree_name"] == "my-tree"
+        assert received["label_selector"] == ["env=prod"]
+
+
+class TestWalkPagesAsyncWithSdkModelResponse:
+    """Tests for walk_pages_async when the list function returns an SDK model object
+    (existing behaviour, should remain unaffected by the dict branch).
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_page(self):
+        async def list_func(cont, limit):
+            return _make_sdk_model(["a", "b"], continue_=None)
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert pages == [["a", "b"]]
+
+    @pytest.mark.asyncio
+    async def test_multiple_pages(self):
+        responses = [
+            _make_sdk_model(["a", "b"], continue_=2),
+            _make_sdk_model(["c"], continue_=None),
+        ]
+
+        async def list_func(cont, limit):
+            return responses.pop(0)
+
+        pages = await _collect(walk_pages_async(list_func, limit=2))
+        assert pages == [["a", "b"], ["c"]]
+
+    @pytest.mark.asyncio
+    async def test_last_page_with_non_null_continue(self):
+        """SDK model response: stop when items count < limit even if continue is set."""
+        responses = [
+            _make_sdk_model(list(range(50)), continue_=50),
+            _make_sdk_model(list(range(5)), continue_=5),
+        ]
+
+        async def list_func(cont, limit):
+            return responses.pop(0)
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert len(pages) == 2
+        assert len(pages[0]) == 50
+        assert len(pages[1]) == 5
+
+    @pytest.mark.asyncio
+    async def test_empty_items_stops_iteration(self):
+        async def list_func(cont, limit):
+            return _make_sdk_model([], continue_=5)
+
+        pages = await _collect(walk_pages_async(list_func))
+        assert pages == []

--- a/tests/sync_tests/test_configtree.py
+++ b/tests/sync_tests/test_configtree.py
@@ -167,6 +167,32 @@ def test_commit_revision_success(client, mocker: MockFixture):
     assert response["metadata"]["name"] == "test_revision"
 
 
+def test_commit_revision_with_labels(client, mocker: MockFixture):
+    mock_patch = mocker.patch("httpx.Client.patch")
+    mock_patch.return_value = httpx.Response(
+        status_code=200,
+        json={
+            "metadata": {
+                "guid": "test_revision_guid",
+                "name": "test_revision",
+                "labels": {"rapyuta.io/milestone": "v1.0"},
+            },
+        },
+    )
+    response = client.commit_revision(
+        tree_name="mock_configtree_name",
+        revision_id="mock_revision_id",
+        labels={"rapyuta.io/milestone": "v1.0"},
+    )
+    assert response["metadata"]["guid"] == "test_revision_guid"
+    assert response["metadata"]["labels"]["rapyuta.io/milestone"] == "v1.0"
+
+    # Verify the request body included metadata.labels
+    call_kwargs = mock_patch.call_args
+    body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+    assert body["metadata"]["labels"] == {"rapyuta.io/milestone": "v1.0"}
+
+
 def test_get_key_in_revision_str(client, mocker: MockFixture):  # noqa: F811
     # Mock the httpx.Client.get method
     mock_get = mocker.patch("httpx.Client.get")

--- a/tests/sync_tests/test_utils.py
+++ b/tests/sync_tests/test_utils.py
@@ -1,0 +1,153 @@
+from rapyuta_io_sdk_v2 import walk_pages
+
+
+def _make_sdk_model(items, continue_=None):
+    """Simulate an SDK model response (object with attributes)."""
+
+    class Metadata:
+        pass
+
+    class Response:
+        pass
+
+    meta = Metadata()
+    meta.continue_ = continue_
+
+    resp = Response()
+    resp.items = items
+    resp.metadata = meta
+    return resp
+
+
+class TestWalkPagesWithDictResponse:
+    """Tests for walk_pages when the list function returns a plain dict
+    (e.g. list_configtrees, list_revisions in the configtree SDK client).
+    """
+
+    def test_single_page(self):
+        calls = []
+
+        def list_func(cont, limit):
+            calls.append((cont, limit))
+            return {"items": ["a", "b"], "metadata": {"continue": None}}
+
+        pages = list(walk_pages(list_func))
+        assert pages == [["a", "b"]]
+        assert len(calls) == 1
+
+    def test_multiple_pages(self):
+        responses = [
+            {"items": ["a", "b"], "metadata": {"continue": 2}},
+            {"items": ["c", "d"], "metadata": {"continue": 4}},
+            {"items": ["e"], "metadata": {"continue": None}},
+        ]
+        calls = []
+
+        def list_func(cont, limit):
+            calls.append(cont)
+            return responses.pop(0)
+
+        pages = list(walk_pages(list_func, limit=2))
+        assert pages == [["a", "b"], ["c", "d"], ["e"]]
+        assert calls == [0, 2, 4]
+
+    def test_last_page_with_non_null_continue(self):
+        """API may return a non-null continue value on the last page.
+
+        walk_pages must stop when items count < limit to avoid infinite loops.
+        """
+        responses = [
+            {"items": list(range(50)), "metadata": {"continue": 50}},
+            {"items": list(range(5)), "metadata": {"continue": 5}},
+        ]
+        calls = []
+
+        def list_func(cont, limit):
+            calls.append(cont)
+            return responses.pop(0)
+
+        pages = list(walk_pages(list_func))
+        assert len(pages) == 2
+        assert len(pages[0]) == 50
+        assert len(pages[1]) == 5
+        assert calls == [0, 50]
+
+    def test_empty_items_stops_iteration(self):
+        def list_func(cont, limit):
+            return {"items": [], "metadata": {"continue": 5}}
+
+        pages = list(walk_pages(list_func))
+        assert pages == []
+
+    def test_missing_items_key_stops_iteration(self):
+        def list_func(cont, limit):
+            return {"metadata": {"continue": 5}}
+
+        pages = list(walk_pages(list_func))
+        assert pages == []
+
+    def test_missing_metadata_stops_after_first_page(self):
+        def list_func(cont, limit):
+            return {"items": ["x"]}
+
+        pages = list(walk_pages(list_func))
+        assert pages == [["x"]]
+
+    def test_kwargs_forwarded(self):
+        received = {}
+
+        def list_func(cont, limit, tree_name=None, label_selector=None):
+            received["tree_name"] = tree_name
+            received["label_selector"] = label_selector
+            return {"items": ["r1"], "metadata": {}}
+
+        list(walk_pages(list_func, tree_name="my-tree", label_selector=["env=prod"]))
+        assert received["tree_name"] == "my-tree"
+        assert received["label_selector"] == ["env=prod"]
+
+
+class TestWalkPagesWithSdkModelResponse:
+    """Tests for walk_pages when the list function returns an SDK model object
+    (existing behaviour, should remain unaffected by the dict branch).
+    """
+
+    def test_single_page(self):
+        def list_func(cont, limit):
+            return _make_sdk_model(["a", "b"], continue_=None)
+
+        pages = list(walk_pages(list_func))
+        assert pages == [["a", "b"]]
+
+    def test_multiple_pages(self):
+        responses = [
+            _make_sdk_model(["a", "b"], continue_=2),
+            _make_sdk_model(["c"], continue_=None),
+        ]
+
+        def list_func(cont, limit):
+            return responses.pop(0)
+
+        pages = list(walk_pages(list_func, limit=2))
+        assert pages == [["a", "b"], ["c"]]
+
+    def test_last_page_with_non_null_continue(self):
+        """SDK model response: stop when items count < limit even if continue is set."""
+        responses = [
+            _make_sdk_model(list(range(50)), continue_=50),
+            _make_sdk_model(list(range(5)), continue_=5),
+        ]
+
+        def list_func(cont, limit):
+            return responses.pop(0)
+
+        pages = list(walk_pages(list_func))
+        assert len(pages) == 2
+        assert len(pages[0]) == 50
+        assert len(pages[1]) == 5
+
+    def test_empty_items_stops_iteration(self):
+        def list_func(cont, limit):
+            return _make_sdk_model([], continue_=5)
+
+        pages = list(walk_pages(list_func))
+        assert pages == []


### PR DESCRIPTION
## Summary

Previously, `walk_pages` and `walk_pages_async` assumed the list function always returned an SDK model object with `.items` and `.metadata` attributes. Some endpoints (e.g. `list_configtrees`, `list_revisions`) return a plain `dict` instead, causing pagination to silently break.

## Changes

**`rapyuta_io_sdk_v2/utils.py`**
- Updated both `walk_pages` and `walk_pages_async` to detect whether the response is a `dict` or an SDK model object and extract `items` and continuation token accordingly.

**`tests/sync_tests/test_utils.py`** _(new)_
**`tests/async_tests/test_utils_async.py`** _(new)_
- Unit tests covering both dict and SDK model responses for:
  - Single-page results
  - Multi-page pagination (continuation token propagation)
  - Empty `items` stopping iteration
  - Missing `metadata` stopping after first page
  - Extra kwargs being forwarded to the list function