### PR TITLE
fix: coerce datetime and bool values in pydantic model

### DIFF
--- a/rapyuta_io_sdk_v2/models/deployment.py
+++ b/rapyuta_io_sdk_v2/models/deployment.py
@@ -43,6 +43,14 @@ class EnvArgsSpec(BaseModel):
     exposed: bool | None = None
     exposed_name: str | None = Field(default=None, alias="exposedName")
 
+    @field_validator("value", mode="before")
+    @classmethod
+    def coerce_value_to_str(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, str):
+            return str(v).lower() if isinstance(v, bool) else str(v)
+        return v
 
 class DeploymentVolume(BaseModel):
     """Unified volume spec matching Go DeploymentVolume struct."""

--- a/rapyuta_io_sdk_v2/models/utils.py
+++ b/rapyuta_io_sdk_v2/models/utils.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Generic, Literal, TypeVar
 
-from pydantic import AliasChoices, BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 # Type variable for generic list items
 T = TypeVar("T")
@@ -47,6 +48,13 @@ class BaseMetadata(BaseModel):
     createdAt: str | None = Field(default=None, description="Time of resource creation")
     updatedAt: str | None = Field(default=None, description="Time of resource update")
     deletedAt: str | None = Field(default=None, description="Time of resource deletion")
+
+    @field_validator("createdAt", "updatedAt", "deletedAt", mode="before")
+    @classmethod
+    def coerce_datetime_to_str(cls, v):
+        if isinstance(v, datetime):
+            return v.isoformat()
+        return v
 
     # Human-readable names
     organizationName: str | None = Field(default=None, description="Organization name")


### PR DESCRIPTION
https://github.com/rapyuta-robotics/rapyuta_io/issues/1357

After downloading the manifest from IO Console, applying it failed for the Postgris Primary database deployment.

To Reproduce
Steps to reproduce the behavior:

Deploy the Postgis Chart.
Download the primary-database deployment manifest using IO Console.
Apply the downloaded manifest using rio apply command.
Expected behavior
A clear and concise description of what you expected to happen.

The rio apply command should complete and the deployment should be created.