### PR TITLE
ci: migrate GitHub Actions to self-hosted ARC runners

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   verify:
     name: Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
     - uses: actions/checkout@v4
       name: Checkout code

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     environment: release
     permissions:
       id-token: write

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -4,7 +4,7 @@ on: [ push ]
 jobs:
   perform-checks:
     name: Perform checks
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: aks-spot-4cpu
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
## Summary

Migrates all GitHub Actions workflows from GitHub-hosted runners (`ubuntu-latest` / `ubuntu-22.04`) to our self-hosted ARC runners (`aks-spot-4cpu`).

This uses the runner scale sets defined in `rr_ci_apps/gha-arc` which run on our AKS cluster with spot instances for cost optimization.